### PR TITLE
Fix links to issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ INFO: Build completed successfully, 2867 total actions
 
 This tool does not support the following:
 
-- Third-party dependencies (#2)
-- Scala (#3) and Kotlin (#4)
-- Java test targets (#5)
+- Third-party dependencies (https://github.com/bazel-contrib/unused-jvm-deps/issues/2)
+- Scala (https://github.com/bazel-contrib/unused-jvm-deps/issues/3) and Kotlin (https://github.com/bazel-contrib/unused-jvm-deps/issues/4)
+- Java test targets (https://github.com/bazel-contrib/unused-jvm-deps/issues/5)


### PR DESCRIPTION
Cleanup after #6 – I should've noticed that [GitHub docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) say that links are only added in "comments"