### PR TITLE
Setup automated testing with GitHub Workflows

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,0 +1,13 @@
+# This file contains Bazel settings to apply on CI only.
+# It is referenced with a --bazelrc option in the call to bazel in ci.yaml
+
+# Debug where options came from
+build --announce_rc
+# This directory is configured in GitHub actions to be persisted between runs.
+build --disk_cache=~/.cache/bazel
+build --repository_cache=~/.cache/bazel-repo
+# Don't rely on test logs being easily accessible from the test runner,
+# though it makes the log noisier.
+test --test_output=errors
+# Allows tests to run bazelisk-in-bazel, since this is the cache folder used
+test --test_env=XDG_CACHE_HOME

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: bazel_from_bazelversion
-        run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
+      # XXX(JohnMurray): Add additional values here if we want to test with multiple
+      #                  versions of bazel.
+      #- id: bazel_from_bazelversion
+      #  run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_5
         run: echo "bazelversion=5.3.2" >> $GITHUB_OUTPUT
     outputs:
@@ -47,7 +49,6 @@ jobs:
         bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
         folder:
           - "."
-          - "e2e/workspace"
     
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
+  group: {{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # matrix-prep-* steps generate JSON used to create a dynamic actions matrix.
+  # Insanely complex for how simple this requirement is inspired from
+  # https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
+
+  matrix-prep-bazelversion:
+    # Prepares the 'bazelversion' axis of the test matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: bazel_from_bazelversion
+        run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
+      - id: bazel_5
+        run: echo "bazelversion=5.3.2" >> $GITHUB_OUTPUT
+    outputs:
+      # Will look like ["<version from .bazelversion>", "5.3.2"]
+      bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
+
+  test:
+    # the type of runner the job will run on
+    runs-on: ubuntu-latest
+
+    needs:
+      - matrix-prep-bazelversion
+    
+    # Run bazel test in each workspace with each version of Bazel supported
+    strategy:
+      fail-fast: false
+      matrix:
+      bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
+        folder:
+          - "."
+          - "e2e/workspace"
+    
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Cache build and external artifacts so that the next ci build is incremental.
+      # Because github action caches cannot be updated after a build, we need to
+      # store the contents of each build in a unique cache key, then fall back to loading
+      # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
+      # the prefix to load the most recent cache for the branch on a cache miss. You
+      # should customize the contents of hashFiles to capture any bazel input sources,
+      # although this doesn't need to be perfect. If none of the input sources change
+      # then a cache hit will load an existing cache and bazel won't have to do any work.
+      # In the case of a cache miss, you want the fallback cache to contain most of the
+      # previously built artifacts to minimize build time. The more precise you are with
+      # hashFiles sources the less work bazel will have to do.
+      - name: Mount bazel caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            "~/.cache/bazel"
+            "~/.cache/bazel-repo"
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          restore-keys: bazel-cache-
+
+      - name: Configure Bazel version
+        working-directory: ${{ matrix.folder }}
+        run: echo "${{ matrix.bazelversion }}" > .bazelversion
+      
+      - name: bazel test //...
+        env:
+          # Bazelisk will download bazel to here, ensure it is cached between runs.
+          XDG_CACHE_HOME: ~/.cache/bazel-repo
+        working-directory: ${{ matrix.folder }}
+        run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
-  group: {{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-      bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
+        bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
         folder:
           - "."
           - "e2e/workspace"

--- a/src/test/plugin/StripeDependencyAnalyzerPluginTest.java
+++ b/src/test/plugin/StripeDependencyAnalyzerPluginTest.java
@@ -195,7 +195,8 @@ public class StripeDependencyAnalyzerPluginTest {
             .add(
                 "java.beans.JavaBean",
                 "javax.annotation.Nullable",
-                "javax.validation.constraints.Positive",
+                "javax.annotation.processing.Generated",
+                "javax.annotation.processing.Generated.value",
                 "java.lang.annotation.Annotation",
                 "java.lang.String",
                 // interfaces implemented / classes extended by String

--- a/src/testResources/plugin/ImportsAnnotations.java
+++ b/src/testResources/plugin/ImportsAnnotations.java
@@ -2,12 +2,13 @@ package uppsala.src.test.resources.com.stripe.build.dependencyanalyzer;
 
 import java.beans.JavaBean;
 import javax.annotation.Nullable;
-import javax.validation.constraints.Positive;
+import javax.annotation.processing.Generated;
 
 @JavaBean
 public class ImportsAnnotations {
 
-  @Positive public int annotatedField = 1;
+  @Generated(value="com.example.MyGenerator")
+  public int annotatedField = 1;
 
   @Nullable
   public String annotatedMethod() {


### PR DESCRIPTION
## Summary

Adding GitHub workflow to run for `main` branch as well as all 
pull-requests to `main`. Example of passing workflow for this
PR: https://github.com/bazel-contrib/unused-jvm-deps/actions/runs/3751014686

__Decision Log__:
  + This was copied from the [rules-template](https://github.com/bazel-contrib/rules-template) repo and modified for our purposes.
  + I've kept the test-matrix code to easily support >1 Bazel versions in the future
  + This is currently pinned to Bazel 5.3.2
  + The Java version is not explicitly specivied

__Note__: I ran into some issues with `bazel test` on Ubuntu 20.10
with Java 19, encountering an annotation in the test that no longer
exists. I've updated the test with a current annotation that
compiles/passes.

Resolves #8 