### PR TITLE
executable permissions + param-forwarding fix

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec bazelisk "$0"
+exec bazelisk "$@"


### PR DESCRIPTION
Add executable permissions and change the parameter forwarding to pass all parameters (excluding `$0`).