### PR TITLE
[aspect] Drop user-defined -Xplugin flags

### DIFF
--- a/src/resources/cli/defs.bzl.override
+++ b/src/resources/cli/defs.bzl.override
@@ -7,7 +7,10 @@ def _analyzer_impl(target, ctx):
 
     orig_java_info = target[JavaInfo]
 
-    # Merge our javac opts, but drop any other plugins that may be in use
+    # Merge our javac opts, but drop any other plugins that may be in use. This is to account
+    # for the fact that the `java_common.compile` action will only run with the dependency
+    # analyzer plugin. Extra defined plugins will cause javac to complain about unknown plugins
+    # if not removed.
     javac_opts = [
         "-Xplugin:'StripeDependencyAnalyzerPlugin {}'".format(str(target.label)),
         "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",

--- a/src/resources/cli/defs.bzl.override
+++ b/src/resources/cli/defs.bzl.override
@@ -7,6 +7,15 @@ def _analyzer_impl(target, ctx):
 
     orig_java_info = target[JavaInfo]
 
+    # Merge our javac opts, but drop any other plugins that may be in use
+    javac_opts = [
+        "-Xplugin:'StripeDependencyAnalyzerPlugin {}'".format(str(target.label)),
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    ]
+    for opt in (orig_java_info.compilation_info.javac_options if orig_java_info.compilation_info else []):
+        if not opt.startswith('-Xplugin:'):
+            javac_opts.append(opt)
+
     # For example, this will extract the file into a file name like "src.main.java.com.stripe.horizon.build.testpkg--testpkg-unused-analysis.json"
     output_jar_name = "{}--{}-unused-analysis.jar".format(target.label.package.replace("/", "."), target.label.name)
 
@@ -15,10 +24,7 @@ def _analyzer_impl(target, ctx):
         ctx,
         java_toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo],
         source_jars = orig_java_info.source_jars,
-        javac_opts = (orig_java_info.compilation_info.javac_options if orig_java_info.compilation_info else []) + [
-            "-Xplugin:'StripeDependencyAnalyzerPlugin {}'".format(str(target.label)),
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-        ],
+        javac_opts = javac_opts,
         output = output_jar,
         plugins = [ctx.attr._analyzer[JavaPluginInfo]],
         deps = [


### PR DESCRIPTION
### Summary

Update `javac_opts` used in aspects call to `java_common.compile` to drop any existing (user-defined) `-Xplugin` options. This fixes an issue in which compilation fails due to missing plugins (since the aspect does not proxy plugin information to the compilation command).

### Motivation

Resolves issue encountered while running tool on internal codebase.

### Testing

Validated manually.