### PR TITLE
Don't print symbols files as compiler diagnostic notes

### DIFF
--- a/src/main/plugin/StripeDependencyAnalyzerPlugin.java
+++ b/src/main/plugin/StripeDependencyAnalyzerPlugin.java
@@ -65,11 +65,6 @@ public class StripeDependencyAnalyzerPlugin implements Plugin {
               SymbolCollectionResult result, CompilationUnitTree compilationUnit) {
             try {
               fileManager.writeResultsToSymbolsFile(result);
-              trees.printMessage(
-                  javax.tools.Diagnostic.Kind.NOTE,
-                  result.toJsonString(),
-                  compilationUnit,
-                  compilationUnit);
             } catch (IOException ex) {
               trees.printMessage(
                   javax.tools.Diagnostic.Kind.ERROR,


### PR DESCRIPTION
This was likely left in during debugging but is not very useful.

Before:
```
uppsala/src/main/java/com/stripe/build/errorprone/performance/ParallelStreamChecker.java:1: Note: {
package com.stripe.build.errorprone.performance;
^
    "sourceFileName": "uppsala/src/main/java/com/stripe/build/errorprone/performance/ParallelStreamChecker.java",
    "packageName": "com.stripe.build.errorprone.performance",
    "bazelTargetLabel": "//uppsala/src/main/java/com/stripe/build/errorprone:global_plugins_lib",
    "exportedSymbols": [
      "com.stripe.build.errorprone.performance.ParallelStreamChecker",
      "com.stripe.build.errorprone.performance.ParallelStreamChecker.\u003cinit\u003e",
      "com.stripe.build.errorprone.performance.ParallelStreamChecker.matchMethodInvocation"
    ],
    "importedSymbols": [
      "com.google.auto.service.AutoService",
      "com.google.auto.service.AutoService.value",
      "com.google.errorprone.BugPattern",
      "com.google.errorprone.BugPattern.LinkType",
      "com.google.errorprone.BugPattern.LinkType.CUSTOM",
      "com.google.errorprone.BugPattern.SeverityLevel",
      "com.google.errorprone.BugPattern.SeverityLevel.ERROR",
      "com.google.errorprone.BugPattern.StandardTags",
      "com.google.errorprone.BugPattern.StandardTags.PERFORMANCE",
      "com.google.errorprone.BugPattern.disableable",
      "com.google.errorprone.BugPattern.documentSuppression",
      "com.google.errorprone.BugPattern.link",
      "com.google.errorprone.BugPattern.linkType",
      "com.google.errorprone.BugPattern.name",
      "com.google.errorprone.BugPattern.severity",
      "com.google.errorprone.BugPattern.summary",
      "com.google.errorprone.BugPattern.suppressionAnnotations",
      "com.google.errorprone.BugPattern.tags",
      "com.google.errorprone.VisitorState",
      "com.google.errorprone.bugpatterns.BugChecker",
      "com.google.errorprone.bugpatterns.BugChecker.\u003cinit\u003e",
      "com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher",
      "com.google.errorprone.bugpatterns.BugChecker.buildDescription",
      "com.google.errorprone.bugpatterns.BugChecker.class",
      "com.google.errorprone.matchers.Description",
      "com.google.errorprone.matchers.Description.Builder",
      "com.google.errorprone.matchers.Description.Builder.build",
      "com.google.errorprone.matchers.Description.Builder.setMessage",
      "com.google.errorprone.matchers.Description.NO_MATCH",
      "com.google.errorprone.matchers.Matcher",
      "com.google.errorprone.matchers.Matcher.T",
      "com.google.errorprone.matchers.Matcher.matches",
      "com.google.errorprone.matchers.Matchers",
      "com.google.errorprone.matchers.Matchers.instanceMethod",
      "com.google.errorprone.matchers.Suppressible",
      "com.google.errorprone.matchers.method.MethodMatchers.InstanceMethodMatcher",
      "com.google.errorprone.matchers.method.MethodMatchers.InstanceMethodMatcher.onDescendantOf",
      "com.google.errorprone.matchers.method.MethodMatchers.MethodClassMatcher",
      "com.google.errorprone.matchers.method.MethodMatchers.MethodClassMatcher.withNameMatching",
      "com.google.errorprone.matchers.method.MethodMatchers.MethodMatcher",
      "com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher",
      "com.google.errorprone.suppliers.Supplier",
      "com.sun.source.tree.ExpressionTree",
      "com.sun.source.tree.MethodInvocationTree",
      "com.sun.source.tree.Tree",
      "com.sun.tools.javac.tree.JCTree",
      "com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition",
      "java.io.Serializable",
      "java.lang.CharSequence",
      "java.lang.Class",
      "java.lang.Comparable",
      "java.lang.Enum",
      "java.lang.Object",
      "java.lang.Override",
      "java.lang.String",
      "java.lang.String.format",
      "java.lang.SuppressWarnings",
      "java.lang.SuppressWarnings.class",
      "java.lang.annotation.Annotation",
      "java.util.Locale",
      "java.util.regex.Pattern",
      "java.util.regex.Pattern.compile"
    ]
  }
INFO: From Building uppsala/src/main/java/com/stripe/build/bazelutil/libbazelutil.jar (1 source file):
uppsala/src/main/java/com/stripe/build/bazelutil/BazelUtil.java:1: Note: {
package com.stripe.build.bazelutil;
^
    "sourceFileName": "uppsala/src/main/java/com/stripe/build/bazelutil/BazelUtil.java",
    "packageName": "com.stripe.build.bazelutil",
    "bazelTargetLabel": "//uppsala/src/main/java/com/stripe/build/bazelutil:bazelutil",
    "exportedSymbols": [
      "com.stripe.build.bazelutil.BazelUtil",
      "com.stripe.build.bazelutil.BazelUtil.getWorkingDirectory"
    ],
    "importedSymbols": [
      "java.io.Serializable",
      "java.lang.CharSequence",
      "java.lang.Comparable",
      "java.lang.Iterable",
      "java.lang.Object",
      "java.lang.Object.\u003cinit\u003e",
      "java.lang.String",
      "java.lang.String.isEmpty",
      "java.lang.System",
      "java.lang.System.getenv",
      "java.net.URI",
      "java.nio.file.Path",
      "java.nio.file.Path.of",
      "java.nio.file.Path.toAbsolutePath",
      "java.nio.file.Paths",
      "java.nio.file.Paths.get",
      "java.nio.file.Watchable",
      "java.util.Map"
    ]
  }
INFO: Elapsed time: 2.999s, Critical Path: 2.16s
INFO: 14 processes: 1 internal, 6 local, 7 worker.
INFO: Build completed successfully, 14 total actions
```

After:
```
INFO: Analyzed target //uppsala/src/main/java/com/stripe/build/bazelutil:bazelutil (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
INFO: Elapsed time: 2.998s, Critical Path: 2.33s
INFO: 15 processes: 6 disk cache hit, 1 internal, 8 worker.
INFO: Build completed successfully, 15 total actions
```